### PR TITLE
:sparkes: Allow users to override the default HEAD branch of the repository

### DIFF
--- a/src/commands/generate.rs
+++ b/src/commands/generate.rs
@@ -1,9 +1,16 @@
 use std::process;
 
+use clap::ArgMatches;
+
 use crate::utils::{config, github, loader, openai};
 
-pub async fn run() {
-    let diff = github::get_diff();
+pub async fn run(sub_matches: &ArgMatches) {
+    let default_branch = github::get_default_branch();
+    let base = sub_matches
+        .get_one::<String>("branch")
+        .unwrap_or(&default_branch);
+
+    let diff = github::get_diff(base);
     if diff.is_empty() {
         println!("No diff found");
         return;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use clap::{self, Command};
+use clap::{self, ArgAction, Command};
 use human_panic::setup_panic;
 
 mod commands;
@@ -10,8 +10,28 @@ fn cli() -> Command {
         .version(env!("CARGO_PKG_VERSION"))
         .subcommand_required(true)
         .arg_required_else_help(true)
-        .subcommand(Command::new("create").about("Creates a PR with a generated description"))
-        .subcommand(Command::new("generate").about("Generates a PR description and outputs it"))
+        .subcommand(
+            Command::new("create")
+                .about("Creates a PR with a generated description")
+                .arg(
+                    clap::Arg::new("branch")
+                        .short('b')
+                        .long("branch")
+                        .help("The base branch to point your changes to")
+                        .action(ArgAction::Set),
+                ),
+        )
+        .subcommand(
+            Command::new("generate")
+                .about("Generates a PR description and outputs it")
+                .arg(
+                    clap::Arg::new("branch")
+                        .short('b')
+                        .long("branch")
+                        .help("The base branch to point your changes to")
+                        .action(ArgAction::Set),
+                ),
+        )
         .subcommand(
             Command::new("config")
                 .about("Configure propr to your liking")
@@ -32,8 +52,8 @@ async fn main() {
 
     let matches = cli().get_matches();
     match matches.subcommand() {
-        Some(("create", _sub_matches)) => commands::create::run().await,
-        Some(("generate", _sub_matches)) => commands::generate::run().await,
+        Some(("create", sub_matches)) => commands::create::run(sub_matches).await,
+        Some(("generate", sub_matches)) => commands::generate::run(sub_matches).await,
         Some(("config", sub_matches)) => commands::config::run(sub_matches),
         _ => unreachable!(),
     }

--- a/src/utils/github.rs
+++ b/src/utils/github.rs
@@ -52,8 +52,8 @@ pub fn get_default_branch() -> String {
         .to_string()
 }
 
-pub fn get_diff() -> String {
-    let output = execute_command("git", &["diff", "origin/HEAD"]);
+pub fn get_diff(base_branch: &str) -> String {
+    let output = execute_command("git", &["diff", base_branch]);
 
     String::from_utf8(output.stdout).unwrap().trim().to_owned()
 }


### PR DESCRIPTION
### Description
This PR enhances the `create` and `generate` commands by allowing users to specify a base branch for their changes. If no base branch is provided, the default branch will be used as the base.

### Added
- Added `branch` argument to the `create` and `generate` commands, allowing users to specify the base branch for their changes.

### Changed
- Modified `get_diff()` function in `github.rs` to accept a base branch as an argument.

### Fixed

### Removed