### PR TITLE
:sparkles: Allow user to specify assistant

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,6 +82,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6"
 
 [[package]]
+name = "async-convert"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d416feee97712e43152cd42874de162b8f9b77295b1c85e5d92725cc8310bae"
+dependencies = [
+ "async-trait",
+]
+
+[[package]]
+name = "async-openai"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3c6ce3eb96d0957f9d5af15b5b0d651e27da8b567d126ef7fefb889d21dda06"
+dependencies = [
+ "async-convert",
+ "backoff",
+ "base64 0.21.0",
+ "bytes",
+ "derive_builder",
+ "futures",
+ "rand",
+ "reqwest",
+ "reqwest-eventsource",
+ "secrecy",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -89,7 +123,7 @@ checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.42",
 ]
 
 [[package]]
@@ -97,6 +131,20 @@ name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "backoff"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
+dependencies = [
+ "futures-core",
+ "getrandom",
+ "instant",
+ "pin-project-lite",
+ "rand",
+ "tokio",
+]
 
 [[package]]
 name = "backtrace"
@@ -139,15 +187,18 @@ checksum = "9b1ce199063694f33ffb7dd4e0ee620741495c32833cde5aa08f02a0bf96f0c8"
 
 [[package]]
 name = "bytes"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
+checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
 
 [[package]]
 name = "cc"
-version = "1.0.79"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "cfg-if"
@@ -277,7 +328,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn 2.0.15",
+ "syn 2.0.42",
 ]
 
 [[package]]
@@ -294,7 +345,73 @@ checksum = "2345488264226bf682893e25de0769f3360aac9957980ec49361b083ddaa5bc5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.42",
+]
+
+[[package]]
+name = "darling"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d67778784b508018359cbc8696edb3db78160bab2c2a28ba7f56ef6932997f8"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c11bdc11a0c47bc7d37d582b5285da6849c96681023680b906673c5707af7b0f"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebcda35c7a396850a55ffeac740804b40ffec779b98fffbb1738f4033f0ee79e"
+dependencies = [
+ "derive_builder_core",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -399,6 +516,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "eventsource-stream"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74fef4569247a5f429d9156b9d0a2599914385dd189c539334c625d8099d90ab"
+dependencies = [
+ "futures-core",
+ "nom",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "fastrand"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -493,7 +621,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.42",
 ]
 
 [[package]]
@@ -507,6 +635,12 @@ name = "futures-task"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
 
 [[package]]
 name = "futures-util"
@@ -528,9 +662,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.9"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
+checksum = "fe9006bed769170c11f845cf00c7c1e9092aeb3f268e007c3e760ac68008070f"
 dependencies = [
  "cfg-if",
  "libc",
@@ -671,6 +805,19 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1788965e61b367cd03a62950836d5cd41560c3577d90e40e0819373194d1661c"
+dependencies = [
+ "http",
+ "hyper",
+ "rustls 0.20.9",
+ "tokio",
+ "tokio-rustls 0.23.4",
+]
+
+[[package]]
+name = "hyper-rustls"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0646026eb1b3eea4cd9ba47912ea5ce9cc07713d105b1a14698f4e6433d348b7"
@@ -678,10 +825,10 @@ dependencies = [
  "http",
  "hyper",
  "log",
- "rustls",
+ "rustls 0.21.1",
  "rustls-native-certs",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.0",
 ]
 
 [[package]]
@@ -732,6 +879,12 @@ dependencies = [
  "cxx",
  "cxx-build",
 ]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -814,7 +967,7 @@ checksum = "6971da4d9c3aa03c3d8f3ff0f4155b534aad021292003895a469716b2a230378"
 dependencies = [
  "base64 0.21.0",
  "pem",
- "ring",
+ "ring 0.16.20",
  "serde",
  "serde_json",
  "simple_asn1",
@@ -828,9 +981,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.144"
+version = "0.2.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
+checksum = "302d7ab3130588088d277783b1e2d2e10c9e9e4a16dd9050e6ec93fb3e7048f4"
 
 [[package]]
 name = "link-cplusplus"
@@ -885,6 +1038,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -921,6 +1090,16 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -990,7 +1169,7 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
- "hyper-rustls",
+ "hyper-rustls 0.24.0",
  "hyper-timeout",
  "jsonwebtoken",
  "once_cell",
@@ -1038,7 +1217,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.42",
 ]
 
 [[package]]
@@ -1153,10 +1332,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.56"
+name = "ppv-lite86"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.71"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75cb1540fadbd5b8fbccc4dddad2734eba435053f725621c070711a14bb5f4b8"
 dependencies = [
  "unicode-ident",
 ]
@@ -1165,6 +1350,7 @@ dependencies = [
 name = "propr"
 version = "1.2.1"
 dependencies = [
+ "async-openai",
  "clap",
  "confy",
  "dialoguer",
@@ -1180,11 +1366,41 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.27"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f4f29d145265ec1c483c7c654450edde0bfe043d3938d6972630663356d9500"
+checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]
@@ -1231,26 +1447,50 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
+ "hyper-rustls 0.23.2",
  "hyper-tls",
  "ipnet",
  "js-sys",
  "log",
  "mime",
+ "mime_guess",
  "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
+ "rustls 0.20.9",
+ "rustls-native-certs",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls 0.23.4",
+ "tokio-util",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "winreg",
+]
+
+[[package]]
+name = "reqwest-eventsource"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f03f570355882dd8d15acc3a313841e6e90eddbc76a93c748fd82cc13ba9f51"
+dependencies = [
+ "eventsource-stream",
+ "futures-core",
+ "futures-timer",
+ "mime",
+ "nom",
+ "pin-project-lite",
+ "reqwest",
+ "thiserror",
 ]
 
 [[package]]
@@ -1262,10 +1502,24 @@ dependencies = [
  "cc",
  "libc",
  "once_cell",
- "spin",
- "untrusted",
+ "spin 0.5.2",
+ "untrusted 0.7.1",
  "web-sys",
  "winapi",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "688c63d65483050968b2a8937f7995f443e27041a0f7700aa59b0822aedebb74"
+dependencies = [
+ "cc",
+ "getrandom",
+ "libc",
+ "spin 0.9.8",
+ "untrusted 0.9.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1290,12 +1544,24 @@ dependencies = [
 
 [[package]]
 name = "rustls"
+version = "0.20.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b80e3dec595989ea8510028f30c408a4630db12c9cbb8de34203b89d6577e99"
+dependencies = [
+ "log",
+ "ring 0.16.20",
+ "sct",
+ "webpki",
+]
+
+[[package]]
+name = "rustls"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c911ba11bc8433e811ce56fde130ccf32f5127cab0e0194e9c68c5a5b671791e"
 dependencies = [
  "log",
- "ring",
+ "ring 0.16.20",
  "rustls-webpki",
  "sct",
 ]
@@ -1327,8 +1593,8 @@ version = "0.100.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6207cd5ed3d8dca7816f8f3725513a34609c0c765bf652b8c3cb4cfd87db46b"
 dependencies = [
- "ring",
- "untrusted",
+ "ring 0.16.20",
+ "untrusted 0.7.1",
 ]
 
 [[package]]
@@ -1370,8 +1636,8 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
 dependencies = [
- "ring",
- "untrusted",
+ "ring 0.16.20",
+ "untrusted 0.7.1",
 ]
 
 [[package]]
@@ -1380,6 +1646,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
 dependencies = [
+ "serde",
  "zeroize",
 ]
 
@@ -1408,29 +1675,29 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.162"
+version = "1.0.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71b2f6e1ab5c2b98c05f0f35b236b22e8df7ead6ffbf51d7808da7f8817e7ab6"
+checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.162"
+version = "1.0.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2a0814352fd64b58489904a44ea8d90cb1a91dcb6b4f5ebabc32c8318e93cb6"
+checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.42",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.96"
+version = "1.0.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "057d394a50403bcac12672b2b18fb387ab6d289d957dab67dd201875391e52f1"
+checksum = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b"
 dependencies = [
  "itoa",
  "ryu",
@@ -1549,6 +1816,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
 name = "spinners"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1600,9 +1873,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.15"
+version = "2.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a34fcf3e8b60f57e6a14301a2e916d323af98b0ea63c599441eec8558660c822"
+checksum = "5b7d0a2c048d661a1a59fcd7355baa232f7ed34e0ee4df2eef3c1c1c0d3852d8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1648,7 +1921,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.42",
 ]
 
 [[package]]
@@ -1730,7 +2003,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.42",
 ]
 
 [[package]]
@@ -1745,11 +2018,33 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
+version = "0.23.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
+dependencies = [
+ "rustls 0.20.9",
+ "tokio",
+ "webpki",
+]
+
+[[package]]
+name = "tokio-rustls"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0d409377ff5b1e3ca6437aa86c1eb7d40c134bfec254e44c830defa92669db5"
 dependencies = [
- "rustls",
+ "rustls 0.21.1",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "397c988d37662c7dda6d2208364a706264bf3d6138b11d436cbac0ad38832842"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
  "tokio",
 ]
 
@@ -1879,7 +2174,7 @@ checksum = "0f57e3ca2a01450b1a921183a9c9cbfda207fd822cef4ccb00a65402cbba7a74"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.42",
 ]
 
 [[package]]
@@ -1896,6 +2191,15 @@ name = "try-lock"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
+
+[[package]]
+name = "unicase"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
 name = "unicode-bidi"
@@ -1931,6 +2235,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1962,6 +2272,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "want"
@@ -2046,6 +2362,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
 
 [[package]]
+name = "wasm-streams"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bbae3363c08332cadccd13b67db371814cd214c2524020932f0804b8cf7c078"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2053,6 +2382,16 @@ checksum = "e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed63aea5ce73d0ff405984102c42de94fc55a6b75765d621c65262469b3c9b53"
+dependencies = [
+ "ring 0.17.7",
+ "untrusted 0.9.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ repository = "https://github.com/segersniels/propr-cli/"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+async-openai = "0.17.1"
 clap = "4.2.5"
 confy = "0.5.1"
 dialoguer = "0.10.4"
@@ -20,8 +21,8 @@ dirs = "5.0.1"
 human-panic = "1.1.4"
 octocrab = "0.21.0"
 reqwest = "0.11.17"
-serde = "1.0.160"
-serde_json = "1.0.96"
+serde = { version = "1.0.192", features = ["derive"] }
+serde_json = "1.0.108"
 spinners = "4.1.0"
 tokio = { version = "1.28.0", features = ["full"] }
 

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -58,7 +58,10 @@ pub fn run(sub_matches: &ArgMatches) {
             let enabled = prompt::ask_for_confirmation("Would you like to use an assistant?");
 
             let assistant_id = if enabled {
-                prompt::ask_with_input("Provide the assistant's id")
+                prompt::ask_with_input(
+                    "Provide the assistant's id",
+                    Some(config.assistant.id.clone()),
+                )
             } else {
                 String::from("")
             };

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -1,6 +1,10 @@
 use clap::ArgMatches;
 
-use crate::utils::{config, openai::ALLOWED_MODELS, prompt};
+use crate::utils::{
+    config::{self, AssistantConfig},
+    openai::ALLOWED_MODELS,
+    prompt,
+};
 
 pub fn run(sub_matches: &ArgMatches) {
     let mut config = config::load();
@@ -49,6 +53,26 @@ pub fn run(sub_matches: &ArgMatches) {
             );
 
             println!("{:?}", config);
+        }
+        Some(("assistant", _sub_matches)) => {
+            let enabled = prompt::ask_for_confirmation("Would you like to use an assistant?");
+
+            let assistant_id = if enabled {
+                prompt::ask_with_input("Provide the assistant's id")
+            } else {
+                String::from("")
+            };
+
+            config.assistant = AssistantConfig {
+                enabled,
+                id: if enabled {
+                    assistant_id
+                } else {
+                    config.assistant.id
+                },
+            };
+
+            config::save(config);
         }
         _ => unreachable!(),
     }

--- a/src/commands/create.rs
+++ b/src/commands/create.rs
@@ -55,14 +55,17 @@ pub async fn run(sub_matches: &ArgMatches) {
             .get_one::<String>("model")
             .unwrap_or(&config.model);
 
-        let description = if let Some(assistant_id) = sub_matches.get_one::<String>("assistant-id")
-        {
-            openai::generate_description_through_assistant(assistant_id, &diff, &config.template)
-                .await
-                .unwrap_or_else(|err| {
-                    println!("{}", err);
-                    process::exit(1);
-                })
+        let description = if config.assistant.enabled {
+            openai::generate_description_through_assistant(
+                &config.assistant.id,
+                &diff,
+                &config.template,
+            )
+            .await
+            .unwrap_or_else(|err| {
+                println!("{}", err);
+                process::exit(1);
+            })
         } else {
             openai::generate_description(&config.prompt, &diff, &config.template, model)
                 .await

--- a/src/commands/create.rs
+++ b/src/commands/create.rs
@@ -15,7 +15,7 @@ async fn get_title(body: &str) -> String {
             process::exit(1);
         })
     } else {
-        prompt::ask_with_input("Provide a title for your pull request")
+        prompt::ask_with_input("Provide a title for your pull request", None)
     }
 }
 

--- a/src/commands/create.rs
+++ b/src/commands/create.rs
@@ -54,13 +54,25 @@ pub async fn run(sub_matches: &ArgMatches) {
         let model = sub_matches
             .get_one::<String>("model")
             .unwrap_or(&config.model);
-        let description =
+
+        let description = if let Some(assistant_id) = sub_matches.get_one::<String>("assistant-id")
+        {
+            openai::generate_description_through_assistant(assistant_id, &diff, &config.template)
+                .await
+                .unwrap_or_else(|err| {
+                    println!("{}", err);
+                    process::exit(1);
+                })
+        } else {
             openai::generate_description(&config.prompt, &diff, &config.template, model)
                 .await
                 .unwrap_or_else(|err| {
                     println!("{}", err);
                     process::exit(1);
-                });
+                })
+        };
+
+        // Stop the loader
         loader.stop_with_message("✅ Done\n".into());
 
         // Print the description

--- a/src/commands/generate.rs
+++ b/src/commands/generate.rs
@@ -22,14 +22,29 @@ pub async fn run(sub_matches: &ArgMatches) {
         .get_one::<String>("model")
         .unwrap_or(&config.model);
 
-    match openai::generate_description(&config.prompt, &diff, &config.template, model).await {
-        Ok(description) => {
-            loader.stop_with_message("✅ Done\n".into());
-            println!("{}", description);
+    if let Some(assistant_id) = sub_matches.get_one::<String>("assistant-id") {
+        match openai::generate_description_through_assistant(assistant_id, &diff, &config.template)
+            .await
+        {
+            Ok(description) => {
+                loader.stop_with_message("✅ Done\n".into());
+                println!("{}", description);
+            }
+            Err(e) => {
+                println!("{}", e);
+                process::exit(1);
+            }
         }
-        Err(e) => {
-            println!("{}", e);
-            process::exit(1);
+    } else {
+        match openai::generate_description(&config.prompt, &diff, &config.template, model).await {
+            Ok(description) => {
+                loader.stop_with_message("✅ Done\n".into());
+                println!("{}", description);
+            }
+            Err(e) => {
+                println!("{}", e);
+                process::exit(1);
+            }
         }
     }
 }

--- a/src/commands/generate.rs
+++ b/src/commands/generate.rs
@@ -22,9 +22,13 @@ pub async fn run(sub_matches: &ArgMatches) {
         .get_one::<String>("model")
         .unwrap_or(&config.model);
 
-    if let Some(assistant_id) = sub_matches.get_one::<String>("assistant-id") {
-        match openai::generate_description_through_assistant(assistant_id, &diff, &config.template)
-            .await
+    if config.assistant.enabled {
+        match openai::generate_description_through_assistant(
+            &config.assistant.id,
+            &diff,
+            &config.template,
+        )
+        .await
         {
             Ok(description) => {
                 loader.stop_with_message("✅ Done\n".into());

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,6 +28,12 @@ fn cli() -> Command {
                         .help("Instructs propr to use a specific model")
                         .value_parser(ALLOWED_MODELS)
                         .action(ArgAction::Set),
+                )
+                .arg(
+                    clap::Arg::new("assistant-id")
+                        .long("assistant-id")
+                        .help("Instructs propr to use the specified assistant")
+                        .action(ArgAction::Set),
                 ),
         )
         .subcommand(
@@ -46,6 +52,12 @@ fn cli() -> Command {
                         .long("model")
                         .help("Instructs propr to use a specific model")
                         .value_parser(ALLOWED_MODELS)
+                        .action(ArgAction::Set),
+                )
+                .arg(
+                    clap::Arg::new("assistant-id")
+                        .long("assistant-id")
+                        .help("Instructs propr to use the specified assistant")
                         .action(ArgAction::Set),
                 ),
         )

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,12 +28,6 @@ fn cli() -> Command {
                         .help("Instructs propr to use a specific model")
                         .value_parser(ALLOWED_MODELS)
                         .action(ArgAction::Set),
-                )
-                .arg(
-                    clap::Arg::new("assistant-id")
-                        .long("assistant-id")
-                        .help("Instructs propr to use the specified assistant")
-                        .action(ArgAction::Set),
                 ),
         )
         .subcommand(
@@ -52,12 +46,6 @@ fn cli() -> Command {
                         .long("model")
                         .help("Instructs propr to use a specific model")
                         .value_parser(ALLOWED_MODELS)
-                        .action(ArgAction::Set),
-                )
-                .arg(
-                    clap::Arg::new("assistant-id")
-                        .long("assistant-id")
-                        .help("Instructs propr to use the specified assistant")
                         .action(ArgAction::Set),
                 ),
         )
@@ -78,6 +66,9 @@ fn cli() -> Command {
                     Command::new("list")
                         .alias("ls")
                         .about("List the current configuration"),
+                )
+                .subcommand(
+                    Command::new("assistant").about("Configure whether to use an assistant or not"),
                 ),
         )
 }

--- a/src/utils/config.rs
+++ b/src/utils/config.rs
@@ -2,12 +2,19 @@ use serde::{Deserialize, Serialize};
 use std::process;
 
 #[derive(Debug, Serialize, Deserialize)]
+pub struct AssistantConfig {
+    pub enabled: bool,
+    pub id: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
 #[serde(default)]
 pub struct Config {
     pub model: String,
     pub prompt: String,
     pub template: String,
     pub generate_title: bool,
+    pub assistant: AssistantConfig,
 }
 
 impl Default for Config {
@@ -22,6 +29,10 @@ Do not treat imports and requires as changes or new features. If the provided me
 Don't surround your PR description in codeblocks but still write GitHub supported markdown."#.into(),
             template: r#"# Description"#.into(),
             generate_title: false,
+            assistant: AssistantConfig {
+                enabled: false,
+                id: "".into(),
+            },
         }
     }
 }

--- a/src/utils/openai.rs
+++ b/src/utils/openai.rs
@@ -1,6 +1,15 @@
+use async_openai::{
+    error::{ApiError, OpenAIError},
+    types::{
+        CreateMessageRequestArgs, CreateRunRequestArgs, CreateThreadRequestArgs, MessageContent,
+        RunStatus,
+    },
+    Client,
+};
 use reqwest::Error;
 use serde::Deserialize;
 use std::process;
+use tokio::time::sleep;
 
 pub const ALLOWED_MODELS: [&str; 6] = [
     "gpt-3.5-turbo",
@@ -25,6 +34,28 @@ const FILES_TO_IGNORE: [&str; 11] = [
     "Pipfile.lock",
     "composer.lock",
 ];
+
+#[derive(Deserialize, Debug)]
+struct Message {
+    content: String,
+}
+
+#[derive(Deserialize, Debug)]
+struct Choice {
+    message: Message,
+}
+
+#[derive(Deserialize, Debug)]
+struct ResponseError {
+    message: String,
+    code: String,
+}
+
+#[derive(Deserialize, Debug)]
+struct Response {
+    choices: Option<[Choice; 1]>,
+    error: Option<ResponseError>,
+}
 
 fn split_diff_into_chunks(diff: &str) -> Vec<String> {
     diff.split("diff --git")
@@ -62,26 +93,99 @@ fn generate_system_message_for_diff(system_message: &str, template: &str) -> Str
     )
 }
 
-#[derive(Deserialize, Debug)]
-struct Message {
-    content: String,
+fn generate_user_message(diff: &str, template: &str) -> String {
+    format!(
+        r#"Use the following template to write your description, don't deviate from the template:
+        {}
+
+        The diff:
+        ```diff
+        {}
+        ```
+        "#,
+        template,
+        prepare_diff(diff),
+    )
 }
 
-#[derive(Deserialize, Debug)]
-struct Choice {
-    message: Message,
-}
+async fn get_assistant_response(
+    assistant_id: &str,
+    diff: &str,
+    template: &str,
+) -> Result<String, OpenAIError> {
+    let client = Client::new();
+    let thread_request = CreateThreadRequestArgs::default().build()?;
+    let thread = client.threads().create(thread_request.clone()).await?;
 
-#[derive(Deserialize, Debug)]
-struct ResponseError {
-    message: String,
-    code: String,
-}
+    let user_message = generate_user_message(diff, template);
+    let message = CreateMessageRequestArgs::default()
+        .role("user")
+        .content(user_message)
+        .build()?;
 
-#[derive(Deserialize, Debug)]
-struct Response {
-    choices: Option<[Choice; 1]>,
-    error: Option<ResponseError>,
+    let _message_obj = client
+        .threads()
+        .messages(&thread.id)
+        .create(message)
+        .await?;
+
+    let run_request = CreateRunRequestArgs::default()
+        .assistant_id(assistant_id)
+        .build()?;
+
+    let run = client
+        .threads()
+        .runs(&thread.id)
+        .create(run_request)
+        .await?;
+
+    loop {
+        let run = client.threads().runs(&thread.id).retrieve(&run.id).await?;
+
+        if run.status == RunStatus::Cancelled {
+            break Err(OpenAIError::InvalidArgument("Run was cancelled".into()));
+        } else if run.status == RunStatus::Cancelling {
+            break Err(OpenAIError::InvalidArgument(
+                "Run is in the process of being cancelled".into(),
+            ));
+        } else if run.status == RunStatus::Failed {
+            break Err(OpenAIError::ApiError(ApiError {
+                message: "Run has failed".into(),
+                r#type: Some("run_failed".into()),
+                param: None,
+                code: None,
+            }));
+        } else if run.status == RunStatus::Expired {
+            break Err(OpenAIError::InvalidArgument("Run has expired".into()));
+        }
+
+        match run.status {
+            RunStatus::Completed => {
+                let query = [("limit", "1")];
+                let response = client.threads().messages(&thread.id).list(&query).await?;
+                let message_id = response.data.get(0).unwrap().id.clone();
+                let message = client
+                    .threads()
+                    .messages(&thread.id)
+                    .retrieve(&message_id)
+                    .await?;
+
+                let content = message.content.get(0).unwrap();
+                let text = match content {
+                    MessageContent::Text(text) => text.text.value.clone(),
+                    MessageContent::ImageFile(_) => {
+                        panic!("images are not supported in the terminal")
+                    }
+                };
+
+                return Ok(text);
+            }
+            _ => {
+                // Wait for 1 second before checking the status again
+                sleep(std::time::Duration::from_secs(1)).await;
+            }
+        }
+    }
 }
 
 fn create_payload(model: &str, system_message: &str, content: &str) -> serde_json::Value {
@@ -175,4 +279,13 @@ pub async fn generate_description(
     let body = create_payload(model, &system_message, &prepare_diff(diff));
 
     get_chat_completion(&body).await
+}
+
+/// Generate a PR description using the user specified assistant
+pub async fn generate_description_through_assistant(
+    assistant_id: &str,
+    diff: &str,
+    template: &str,
+) -> Result<String, OpenAIError> {
+    get_assistant_response(assistant_id, diff, template).await
 }

--- a/src/utils/openai.rs
+++ b/src/utils/openai.rs
@@ -1,14 +1,12 @@
 use async_openai::{
     error::{ApiError, OpenAIError},
     types::{
-        CreateMessageRequestArgs, CreateRunRequestArgs, CreateThreadRequestArgs, MessageContent,
-        RunStatus,
+        ChatCompletionRequestSystemMessageArgs, ChatCompletionRequestUserMessageArgs,
+        CreateChatCompletionRequestArgs, CreateMessageRequestArgs, CreateRunRequestArgs,
+        CreateThreadRequestArgs, MessageContent, RunStatus,
     },
     Client,
 };
-use reqwest::Error;
-use serde::Deserialize;
-use std::process;
 use tokio::time::sleep;
 
 pub const ALLOWED_MODELS: [&str; 6] = [
@@ -20,7 +18,7 @@ pub const ALLOWED_MODELS: [&str; 6] = [
     "gpt-4-1106-preview",
 ];
 
-const MAX_TOKEN_LENGTH: i32 = 500;
+const MAX_TOKEN_LENGTH: i32 = 512;
 const FILES_TO_IGNORE: [&str; 11] = [
     "package-lock.json",
     "yarn.lock",
@@ -34,28 +32,6 @@ const FILES_TO_IGNORE: [&str; 11] = [
     "Pipfile.lock",
     "composer.lock",
 ];
-
-#[derive(Deserialize, Debug)]
-struct Message {
-    content: String,
-}
-
-#[derive(Deserialize, Debug)]
-struct Choice {
-    message: Message,
-}
-
-#[derive(Deserialize, Debug)]
-struct ResponseError {
-    message: String,
-    code: String,
-}
-
-#[derive(Deserialize, Debug)]
-struct Response {
-    choices: Option<[Choice; 1]>,
-    error: Option<ResponseError>,
-}
 
 fn split_diff_into_chunks(diff: &str) -> Vec<String> {
     diff.split("diff --git")
@@ -108,7 +84,7 @@ fn generate_user_message(diff: &str, template: &str) -> String {
     )
 }
 
-async fn get_assistant_response(
+async fn get_assistant_completion(
     assistant_id: &str,
     diff: &str,
     template: &str,
@@ -188,84 +164,37 @@ async fn get_assistant_response(
     }
 }
 
-fn create_payload(model: &str, system_message: &str, content: &str) -> serde_json::Value {
-    serde_json::json!({
-        "model": model,
-        "messages": [
-            { "role": "system", "content": system_message },
-            { "role": "user", "content": content }
-        ],
-        "temperature": 0.7,
-        "top_p": 1,
-        "frequency_penalty": 0,
-        "presence_penalty": 0,
-        "max_tokens": MAX_TOKEN_LENGTH,
-    })
-}
+async fn get_completion(
+    model: &str,
+    system_message: &str,
+    content: &str,
+) -> Result<String, OpenAIError> {
+    let client = Client::new();
+    let request = CreateChatCompletionRequestArgs::default()
+        .max_tokens(MAX_TOKEN_LENGTH as u16)
+        .model(model)
+        .messages([
+            ChatCompletionRequestSystemMessageArgs::default()
+                .content(system_message)
+                .build()?
+                .into(),
+            ChatCompletionRequestUserMessageArgs::default()
+                .content(content)
+                .build()?
+                .into(),
+        ])
+        .build()?;
 
-/// Perform a completion request to the OpenAI API
-async fn get_chat_completion(body: &serde_json::Value) -> Result<String, Error> {
-    let api_key = std::env::var("OPENAI_API_KEY").unwrap_or_else(|_| {
-        println!("Error: OPENAI_API_KEY environment variable not set");
-        process::exit(0);
-    });
+    let response = client.chat().create(request).await?;
 
-    let response = reqwest::Client::new()
-        .post("https://api.openai.com/v1/chat/completions")
-        .header(
-            reqwest::header::AUTHORIZATION,
-            format!("Bearer {}", api_key),
-        )
-        .header(reqwest::header::CONTENT_TYPE, "application/json")
-        .body(serde_json::to_string(body).unwrap())
-        .send()
-        .await?;
-
-    let result: Result<String, Error> = response.text().await;
-    match result {
-        Ok(response) => {
-            let data: Response = serde_json::from_str(response.as_str()).unwrap();
-
-            if data.error.is_some() {
-                let error = data.error.unwrap();
-
-                match error.code.as_str() {
-                    "context_length_exceeded" => {
-                        println!("Error: The provided diff is too large. Try using a different model that supports a higher token count or reduce the size of the diff.");
-                        std::process::exit(1);
-                    }
-                    _ => {
-                        println!("Error: {}", error.message);
-                        std::process::exit(1);
-                    }
-                }
-            }
-
-            if let Some(choice) = data.choices {
-                Ok(choice[0].message.content.clone())
-            } else {
-                println!("Error: {}", response.as_str());
-                std::process::exit(1);
-            }
-        }
-        Err(_) => {
-            println!("Error: Could not fetch response from OpenAI");
-            std::process::exit(1);
-        }
-    }
+    Ok(response.choices[0].message.content.clone().unwrap())
 }
 
 /// Generate a concise PR title
-pub async fn generate_title(description: &str) -> Result<String, Error> {
+pub async fn generate_title(description: &str) -> Result<String, OpenAIError> {
     let system_message = "Generate a concise PR title from the provided description prefixed with a suitable gitmoji";
 
-    /*
-    Generate the title using gpt-3.5-turbo since it is the fastest model
-    and we don't want to spend too many tokens on this
-    */
-    let body = create_payload("gpt-3.5-turbo-1106", system_message, description);
-
-    get_chat_completion(&body).await
+    get_completion("gpt-3.5-turbo-1106", system_message, description).await
 }
 
 /// Generate a concise PR description
@@ -274,11 +203,10 @@ pub async fn generate_description(
     diff: &str,
     template: &str,
     model: &str,
-) -> Result<String, Error> {
+) -> Result<String, OpenAIError> {
     let system_message = generate_system_message_for_diff(prompt, template);
-    let body = create_payload(model, &system_message, &prepare_diff(diff));
 
-    get_chat_completion(&body).await
+    get_completion(model, &system_message, &prepare_diff(diff)).await
 }
 
 /// Generate a PR description using the user specified assistant
@@ -287,5 +215,5 @@ pub async fn generate_description_through_assistant(
     diff: &str,
     template: &str,
 ) -> Result<String, OpenAIError> {
-    get_assistant_response(assistant_id, diff, template).await
+    get_assistant_completion(assistant_id, diff, template).await
 }

--- a/src/utils/prompt.rs
+++ b/src/utils/prompt.rs
@@ -19,11 +19,14 @@ pub fn ask_with_prompt(choices: Vec<&str>, message: &str) -> String {
 }
 
 pub fn ask_with_input(message: &str, default: Option<String>) -> String {
-    Input::new()
-        .with_prompt(message)
-        .default(default.unwrap_or_default())
-        .interact()
-        .unwrap()
+    let mut input = Input::new();
+    input.with_prompt(message);
+
+    if let Some(default) = default {
+        input.default(default);
+    }
+
+    input.interact().unwrap()
 }
 
 pub fn ask_for_confirmation(message: &str) -> bool {

--- a/src/utils/prompt.rs
+++ b/src/utils/prompt.rs
@@ -18,8 +18,12 @@ pub fn ask_with_prompt(choices: Vec<&str>, message: &str) -> String {
     choices[choice].to_string()
 }
 
-pub fn ask_with_input(message: &str) -> String {
-    Input::new().with_prompt(message).interact().unwrap()
+pub fn ask_with_input(message: &str, default: Option<String>) -> String {
+    Input::new()
+        .with_prompt(message)
+        .default(default.unwrap_or_default())
+        .interact()
+        .unwrap()
 }
 
 pub fn ask_for_confirmation(message: &str) -> bool {


### PR DESCRIPTION
### Added
- Added the async-openai dependency to the project's Cargo.toml file.
- Added a new struct `AssistantConfig` to the `config.rs` file to handle assistant configuration.
- Added a new subcommand to the `config` command to adjust the system message used in the app's prompt.
- Added a new subcommand to the `config` command to configure whether to use an assistant or not.

### Changed
- Updated the `Cargo.toml` file to adjust dependencies and their versions.
- Updated the `config.rs` file to include the new `AssistantConfig` struct and its configuration options.
- Updated functions in various files to support generating PR descriptions using an assistant if enabled.

### Removed
- Removed a hard-coded model value and replaced it with a configurable value in the `config.rs` file.

The changes include adding a new dependency, introducing a new struct for configuring an assistant, adding subcommands to configure the app's prompt and enable/disable an assistant, and updating functions to support generating PR descriptions using an assistant if enabled.